### PR TITLE
Hack for SPARQL update queries

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,8 @@ function middleware (apiPath, api, options) {
       api: api,
       iri: hydraView.iri,
       basePath: options.basePath,
-      endpointUrl: options.sparqlEndpointUrl,
+      queryUrl: options.sparqlEndpointQueryUrl || options.sparqlEndpointUrl,
+      updateUrl: options.sparqlEndpointUpdateUrl,
       authentication: options.authentication,
       debug: options.debug
     })

--- a/lib/SparqlView.js
+++ b/lib/SparqlView.js
@@ -10,7 +10,8 @@ class SparqlView extends ApiObject {
 
     this.debug = options.debug
 
-    this.endpointUrl = options.endpointUrl
+    this.queryUrl = options.queryUrl
+    this.updateUrl = options.updateUrl
 
     if (options.authentication) {
       this.headers = {
@@ -30,7 +31,8 @@ class SparqlView extends ApiObject {
       this.sparqlQuery = sparqlQuery
 
       this.client = new SparqlHttp({
-        endpointUrl: this.endpointUrl,
+        endpointUrl: this.queryUrl,
+        updateUrl: this.updateUrl,
         fetch: rdfFetch
       })
     })
@@ -50,7 +52,18 @@ class SparqlView extends ApiObject {
       })
     }
 
-    return this.client.constructQuery(query, options).then((result) => {
+    return Promise.resolve().then(() => {
+      // TODO: very ugly hack. maybe we can define different rdf types for update and query SPARQL code
+      if (query.includes('INSERT {')) {
+        return this.client.updateQuery(query, options)
+      } else {
+        return this.client.constructQuery(query, options)
+      }
+    }).then((result) => {
+      if (!result.ok) {
+        return Promise.reject(new Error(result.statusText))
+      }
+
       return result.quadStream()
     }).then((output) => {
       if (output) {

--- a/lib/SparqlView.js
+++ b/lib/SparqlView.js
@@ -53,8 +53,7 @@ class SparqlView extends ApiObject {
     }
 
     return Promise.resolve().then(() => {
-      // TODO: very ugly hack. maybe we can define different rdf types for update and query SPARQL code
-      if (query.includes('INSERT {')) {
+      if (this.source.value.endsWith('.ru')) {
         return this.client.updateQuery(query, options)
       } else {
         return this.client.constructQuery(query, options)

--- a/test/SparqlView.js
+++ b/test/SparqlView.js
@@ -15,14 +15,16 @@ describe('SparqlView', () => {
   it('should assign the options', () => {
     const api = rdf.dataset()
     const iri = rdf.namedNode('http://example.org/')
-    const endpointUrl = 'http://example.org/query'
+    const queryUrl = 'http://example.org/query'
+    const updateUrl = 'http://example.org/update'
 
-    const view = new SparqlView({api, iri, debug: true, endpointUrl})
+    const view = new SparqlView({api, iri, debug: true, queryUrl, updateUrl})
 
     assert.equal(view.api, api)
     assert.equal(view.iri, iri)
     assert.equal(view.debug, true)
-    assert.equal(view.endpointUrl, endpointUrl)
+    assert.equal(view.queryUrl, queryUrl)
+    assert.equal(view.updateUrl, updateUrl)
   })
 
   it('should assign code, source and variables from the API', () => {
@@ -88,13 +90,13 @@ describe('SparqlView', () => {
         rdf.quad(code, ns.hydraBox.source, source)
       ])
 
-      const endpointUrl = 'http://example.org/query'
+      const queryUrl = 'http://example.org/query'
 
-      const view = new SparqlView({api, iri, endpointUrl})
+      const view = new SparqlView({api, iri, queryUrl})
 
       return view.init().then(() => {
         assert.equal(typeof view.client, 'object')
-        assert.equal(view.client.endpointUrl, endpointUrl)
+        assert.equal(view.client.endpointUrl, queryUrl)
       })
     })
   })


### PR DESCRIPTION
Some endpoints don't support update queries on the query URL. With this PR the update queries are detected by simple text search and the update URL is used.