### PR TITLE
feat: expose sparql client to express handlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,12 @@ function middleware (apiPath, api, options) {
 
   const router = new Router()
 
+  router.use((req, res, next) => {
+    req.sparql = client
+    if (next) {
+      next()
+    }
+  })
   router.use(absoluteUrl())
 
   router.jsonldContexts = jsonldContextLink({


### PR DESCRIPTION
Adding SPARQL client to the `req` object so that any handler can perform queries

```js
async (req, res, next) => {
  const dataset = rdf.dataset()

  const const result = await req.sparql.constructQuery('CONSTRUCT ...')
  dataset.import(await result.quadStream())

  res.graph(dataset)
}
```