### PR TITLE
feat: forward base IRI option to @rdfjs/express-handler

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -9,7 +9,7 @@ const iriTemplate = require('./lib/middleware/iriTemplate')
 const operation = require('./lib/middleware/operation')
 const resource = require('./lib/middleware/resource')
 
-function middleware (api, store) {
+function middleware (api, store, { baseIriFromRequest } = {}) {
   const router = new Router()
 
   router.use(absoluteUrl())
@@ -43,7 +43,7 @@ function middleware (api, store) {
 
     next()
   })
-  router.use(rdfHandler())
+  router.use(rdfHandler({ baseIriFromRequest }))
   router.use(apiHeader(api))
   router.use(iriTemplate(api))
   router.use(resource(store))

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@rdfjs/data-model": "^1.1.2",
     "@rdfjs/dataset": "^1.0.1",
-    "@rdfjs/express-handler": "^1.0.2",
+    "@rdfjs/express-handler": "^1.1.0",
     "@rdfjs/namespace": "^1.1.0",
     "@rdfjs/term-set": "^1.0.0",
     "absolute-url": "^1.2.2",


### PR DESCRIPTION
Update @rdfjs/express-handler to use the baseIRI feature