### PR TITLE
use chaining api in Api class

### DIFF
--- a/Api.js
+++ b/Api.js
@@ -28,6 +28,10 @@ class Api {
       return
     }
 
+    if (!this.dataset) {
+      this.dataset = rdf.dataset()
+    }
+
     for (const task of this.tasks) {
       await task()
     }
@@ -47,10 +51,6 @@ class Api {
 
   fromFile (filePath) {
     this.tasks.push(async () => {
-      if (!this.dataset) {
-        this.dataset = rdf.dataset()
-      }
-
       addAll(this.dataset, await fromStream(rdf.dataset(), fromFile(filePath)))
     })
 

--- a/lib/middleware/resource.js
+++ b/lib/middleware/resource.js
@@ -1,6 +1,6 @@
 const debug = require('debug')('hydra-box:resource')
 const clownface = require('clownface')
-const ns = require('../namespaces')
+const ns = require('@tpluscode/rdf-ns-builders')
 const { fromStream } = require('rdf-dataset-ext')
 const rdf = { ...require('@rdfjs/data-model'), ...require('@rdfjs/dataset') }
 const TermSet = require('@rdfjs/term-set')

--- a/lib/middleware/waitFor.js
+++ b/lib/middleware/waitFor.js
@@ -1,0 +1,15 @@
+function waitFor (promise, factory) {
+  let middleware = null
+
+  return async (req, res, next) => {
+    await promise
+
+    if (!middleware) {
+      middleware = factory()
+    }
+
+    middleware(req, res, next)
+  }
+}
+
+module.exports = waitFor

--- a/middleware.js
+++ b/middleware.js
@@ -1,6 +1,7 @@
 const debug = require('debug')('hydra-box:middleware')
 const absoluteUrl = require('absolute-url')
 const { Router } = require('express')
+const { defer } = require('promise-the-world')
 const rdf = { ...require('@rdfjs/data-model'), ...require('@rdfjs/dataset') }
 const rdfHandler = require('@rdfjs/express-handler')
 const setLink = require('set-link')
@@ -8,8 +9,10 @@ const apiHeader = require('./lib/middleware/apiHeader')
 const iriTemplate = require('./lib/middleware/iriTemplate')
 const operation = require('./lib/middleware/operation')
 const resource = require('./lib/middleware/resource')
+const waitFor = require('./lib/middleware/waitFor')
 
 function middleware (api, store, { baseIriFromRequest } = {}) {
+  const init = defer()
   const router = new Router()
 
   router.use(absoluteUrl())
@@ -39,15 +42,24 @@ function middleware (api, store, { baseIriFromRequest } = {}) {
       debug(`api.term was not set. Will use: ${api.term.value}`)
     }
 
-    await api.init()
+    try {
+      await api.init()
 
-    next()
+      init.resolve()
+
+      next()
+    } catch (err) {
+      init.reject(err)
+
+      next(err)
+    }
   })
+
   router.use(rdfHandler({ baseIriFromRequest }))
-  router.use(apiHeader(api))
-  router.use(iriTemplate(api))
+  router.use(waitFor(init, () => apiHeader(api)))
+  router.use(waitFor(init, () => iriTemplate(api)))
   router.use(resource(store))
-  router.use(operation(api))
+  router.use(waitFor(init, () => operation(api)))
 
   return router
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "clownface": "^0.12.1",
     "debug": "^4.1.1",
     "express": "^4.17.1",
+    "promise-the-world": "^1.0.1",
     "rdf-dataset-ext": "^1.0.0",
     "rdf-loader-code": "^0.3.0",
     "rdf-loaders-registry": "^0.2.0",

--- a/test/Api.test.js
+++ b/test/Api.test.js
@@ -1,7 +1,10 @@
 const { strictEqual, ok } = require('assert')
+const { resolve } = require('path')
+const clownface = require('clownface')
 const { describe, it } = require('mocha')
 const rdf = { ...require('@rdfjs/data-model'), ...require('@rdfjs/dataset') }
 const Api = require('../Api')
+const ns = require('../lib/namespaces')
 
 describe('Api', () => {
   it('should be a constructor', () => {
@@ -29,8 +32,84 @@ describe('Api', () => {
     strictEqual(api.path, path)
   })
 
+  describe('fromFile', () => {
+    it('should be a method', () => {
+      const api = new Api()
+
+      strictEqual(typeof api.fromFile, 'function')
+    })
+
+    it('should return the Api instance', () => {
+      const api = new Api()
+
+      const result = api.fromFile('test')
+
+      strictEqual(result, api)
+    })
+
+    it('should create a task', () => {
+      const api = new Api()
+
+      api.fromFile('test')
+
+      strictEqual(api.tasks.length, 1)
+    })
+
+    it('should load the API from the given file when init is called', async () => {
+      const api = new Api()
+
+      api.fromFile(resolve(__dirname, 'support/api.ttl'))
+      await api.init()
+
+      strictEqual(api.dataset.size >= 8, true)
+    })
+  })
+
+  describe('init', () => {
+    it('should be a method', () => {
+      const api = new Api()
+
+      strictEqual(typeof api.init, 'function')
+    })
+
+    it('should be async', () => {
+      const api = new Api({ dataset: rdf.dataset() })
+
+      const result = api.init()
+
+      strictEqual(typeof result.then, 'function')
+      strictEqual(typeof result.catch, 'function')
+    })
+
+    it('should create a hydra:ApiDocumentation triple', async () => {
+      const term = rdf.namedNode('http://example.org/api')
+      const api = new Api({ dataset: rdf.dataset(), term })
+
+      await api.init()
+
+      const apiDoc = clownface({ dataset: api.dataset, term: api.term, graph: api.graph })
+      const subject = apiDoc.has(ns.rdf.type, ns.hydra.ApiDocumentation).term
+
+      strictEqual(term.equals(subject), true)
+    })
+  })
+
   describe('rebase', () => {
-    it('changes the base of IRIs in dataset', () => {
+    it('should be a method', () => {
+      const api = new Api()
+
+      strictEqual(typeof api.rebase, 'function')
+    })
+
+    it('should return the Api instance', () => {
+      const api = new Api()
+
+      const result = api.rebase()
+
+      strictEqual(result, api)
+    })
+
+    it('should change the base of IRIs in the dataset when init is called', async () => {
       // given
       const dataset = rdf.dataset()
         .add(rdf.quad(
@@ -42,6 +121,7 @@ describe('Api', () => {
 
       // when
       api.rebase('http://example.org/', 'http://example.com/')
+      await api.init()
 
       // then
       ok([...api.dataset][0].equals(rdf.quad(

--- a/test/Api.test.js
+++ b/test/Api.test.js
@@ -3,8 +3,8 @@ const { resolve } = require('path')
 const clownface = require('clownface')
 const { describe, it } = require('mocha')
 const rdf = { ...require('@rdfjs/data-model'), ...require('@rdfjs/dataset') }
+const ns = require('@tpluscode/rdf-ns-builders')
 const Api = require('../Api')
-const ns = require('../lib/namespaces')
 
 describe('Api', () => {
   it('should be a constructor', () => {

--- a/test/support/api.ttl
+++ b/test/support/api.ttl
@@ -1,0 +1,15 @@
+@base <http://localhost:9000/api/schema/>.
+
+@prefix hydra: <http://www.w3.org/ns/hydra/core#>.
+@prefix code: <https://code.described.at/>.
+
+<Blog> a hydra:Class;
+  hydra:supportedOperation
+    <blog#get>.
+
+<blog#get> a hydra:SupportedOperation;
+  hydra:method "GET";
+  hydra:returns <Blog>;
+  code:implementedBy [ a code:EcmaScript;
+    code:link <file:./blog.js#get>
+  ].


### PR DESCRIPTION
This PR makes the `.fromFile` method of `Api` chainable by doing the actual file reading and parsing in `.init`. Also the `.rebase` is done in init in the order of the method calls.