### PR TITLE
moved resource loading code to StoreResourceLoader class

### DIFF
--- a/StoreResourceLoader.js
+++ b/StoreResourceLoader.js
@@ -1,0 +1,50 @@
+const clownface = require('clownface')
+const ns = require('@tpluscode/rdf-ns-builders')
+const { fromStream } = require('rdf-dataset-ext')
+const rdf = { ...require('@rdfjs/data-model'), ...require('@rdfjs/dataset') }
+const TermSet = require('@rdfjs/term-set')
+
+class StoreResourceLoader {
+  constructor ({ store }) {
+    this.store = store
+  }
+
+  async load (term) {
+    const dataset = await fromStream(rdf.dataset(), this.store.match(null, null, null, term))
+
+    if (dataset.size === 0) {
+      return null
+    }
+
+    const types = new TermSet(clownface({ dataset, term }).out(ns.rdf.type).terms)
+
+    return {
+      term,
+      dataset,
+      types
+    }
+  }
+
+  async byClass (term) {
+    const resource = await this.load(term)
+
+    return resource ? [resource] : []
+  }
+
+  async byProperty (term) {
+    const dataset = await fromStream(rdf.dataset(), this.store.match(null, null, term, null))
+    const result = []
+
+    for (const quad of dataset) {
+      result.push({
+        property: quad.property,
+        object: quad.object,
+        ...await this.load(quad.subject)
+      })
+    }
+
+    return result
+  }
+}
+
+module.exports = StoreResourceLoader

--- a/StoreResourceLoader.js
+++ b/StoreResourceLoader.js
@@ -25,13 +25,13 @@ class StoreResourceLoader {
     }
   }
 
-  async byClass (term) {
+  async forClassOperation (term) {
     const resource = await this.load(term)
 
     return resource ? [resource] : []
   }
 
-  async byProperty (term) {
+  async forPropertyOperation (term) {
     const dataset = await fromStream(rdf.dataset(), this.store.match(null, null, term, null))
     const result = []
 

--- a/examples/blog/server.js
+++ b/examples/blog/server.js
@@ -17,7 +17,7 @@ async function main () {
 
   const app = express()
   app.locals.store = new ResourceStore({ quadStore: store })
-  app.use(hydraBox(api, store))
+  app.use(hydraBox(api, { store }))
   app.listen(9000)
 }
 

--- a/lib/middleware/resource.js
+++ b/lib/middleware/resource.js
@@ -2,10 +2,10 @@ const debug = require('debug')('hydra-box:resource')
 
 function factory ({ loader }) {
   return async (req, res, next) => {
-    let resources = await loader.byClass(req.hydra.term)
+    let resources = await loader.forClassOperation(req.hydra.term)
 
     if (resources.length === 0) {
-      resources = await loader.byProperty(req.hydra.term)
+      resources = await loader.forPropertyOperation(req.hydra.term)
     }
 
     if (resources.length !== 1) {

--- a/lib/middleware/resource.js
+++ b/lib/middleware/resource.js
@@ -1,47 +1,18 @@
 const debug = require('debug')('hydra-box:resource')
-const clownface = require('clownface')
-const ns = require('../namespaces')
-const { fromStream } = require('rdf-dataset-ext')
-const rdf = { ...require('@rdfjs/data-model'), ...require('@rdfjs/dataset') }
-const TermSet = require('@rdfjs/term-set')
 
-async function loadResource (store, term) {
-  const dataset = await fromStream(rdf.dataset(), store.match(null, null, null, term))
-
-  if (dataset.size === 0) {
-    return null
-  }
-
-  const types = new TermSet(clownface({ dataset, term }).out(ns.rdf.type).terms)
-
-  return {
-    term,
-    dataset,
-    types
-  }
-}
-
-async function findClassResource (store, term) {
-  return loadResource(store, term)
-}
-
-async function findPropertyResource (store, propertyTerm) {
-  const dataset = await fromStream(rdf.dataset(), store.match(null, null, propertyTerm, null))
-
-  if (dataset.size === 0) {
-    return null
-  }
-
-  const term = [...dataset][0].subject
-
-  return loadResource(store, term)
-}
-
-function factory (store) {
+function factory ({ loader }) {
   return async (req, res, next) => {
-    req.hydra.resource =
-      await findClassResource(store, req.hydra.term) ||
-      await findPropertyResource(store, req.hydra.term)
+    let resources = await loader.byClass(req.hydra.term)
+
+    if (resources.length === 0) {
+      resources = await loader.byProperty(req.hydra.term)
+    }
+
+    if (resources.length !== 1) {
+      return next(new Error(`no unique resource found for: <${req.hydra.term.value}>`))
+    }
+
+    req.hydra.resource = resources[0]
 
     if (req.hydra.resource) {
       debug(`IRI: ${req.hydra.resource.term.value}`)

--- a/middleware.js
+++ b/middleware.js
@@ -8,8 +8,9 @@ const apiHeader = require('./lib/middleware/apiHeader')
 const iriTemplate = require('./lib/middleware/iriTemplate')
 const operation = require('./lib/middleware/operation')
 const resource = require('./lib/middleware/resource')
+const StoreResourceLoader = require('./StoreResourceLoader')
 
-function middleware (api, store, { baseIriFromRequest } = {}) {
+function middleware (api, { baseIriFromRequest, loader, store } = {}) {
   const router = new Router()
 
   router.use(absoluteUrl())
@@ -46,7 +47,15 @@ function middleware (api, store, { baseIriFromRequest } = {}) {
   router.use(rdfHandler({ baseIriFromRequest }))
   router.use(apiHeader(api))
   router.use(iriTemplate(api))
-  router.use(resource(store))
+
+  if (loader) {
+    router.use(resource({ loader }))
+  } else if (store) {
+    router.use(resource({ loader: new StoreResourceLoader({ store }) }))
+  } else {
+    throw new Error('no loader or store provided')
+  }
+
   router.use(operation(api))
 
   return router

--- a/test/StoreResourceLoader.test.js
+++ b/test/StoreResourceLoader.test.js
@@ -1,0 +1,91 @@
+const { strictEqual } = require('assert')
+const { resolve } = require('path')
+const { describe, it } = require('mocha')
+const rdf = { ...require('@rdfjs/data-model'), ...require('@rdfjs/dataset') }
+const FlatMultiFileStore = require('rdf-store-fs/FlatMultiFileStore')
+const StoreResourceLoader = require('../StoreResourceLoader')
+
+describe('StoreResourceLoader', () => {
+  it('should be a constructor', () => {
+    strictEqual(typeof StoreResourceLoader, 'function')
+  })
+
+  it('should assign the given store', () => {
+    const store = {}
+    const loader = new StoreResourceLoader({ store })
+
+    strictEqual(loader.store, store)
+  })
+
+  describe('.load', () => {
+    it('should be a method', () => {
+      const loader = new StoreResourceLoader({ store: {} })
+
+      strictEqual(typeof loader.load, 'function')
+    })
+
+    it('should load term, dataset and types from the given named graph', async () => {
+      const term = rdf.namedNode('http://example.org/')
+      const store = new FlatMultiFileStore({
+        baseIRI: 'http://example.org/',
+        path: resolve(__dirname, 'support/store')
+      })
+      const loader = new StoreResourceLoader({ store })
+
+      const resource = await loader.load(term)
+
+      strictEqual(term.equals(resource.term), true)
+      strictEqual(resource.dataset.size, 2)
+      strictEqual([...resource.types][0].value, 'http://example.org/Class')
+    })
+  })
+
+  describe('.byClass', () => {
+    it('should be a method', () => {
+      const loader = new StoreResourceLoader({ store: {} })
+
+      strictEqual(typeof loader.byClass, 'function')
+    })
+
+    it('should load term, dataset and types from the given named graph', async () => {
+      const term = rdf.namedNode('http://example.org/')
+      const store = new FlatMultiFileStore({
+        baseIRI: 'http://example.org/',
+        path: resolve(__dirname, 'support/store')
+      })
+      const loader = new StoreResourceLoader({ store })
+
+      const resources = await loader.byClass(term)
+      const resource = resources[0]
+
+      strictEqual(term.equals(resource.term), true)
+      strictEqual(resource.dataset.size, 2)
+      strictEqual([...resource.types][0].value, 'http://example.org/Class')
+    })
+  })
+
+  describe('.byProperty', () => {
+    it('should be a method', () => {
+      const loader = new StoreResourceLoader({ store: {} })
+
+      strictEqual(typeof loader.byProperty, 'function')
+    })
+
+    it('should load term, dataset and types from the given named graph', async () => {
+      const term = rdf.namedNode('http://example.org/')
+      const link = rdf.namedNode('http://example.org/object')
+      const store = new FlatMultiFileStore({
+        baseIRI: 'http://example.org/',
+        path: resolve(__dirname, 'support/store')
+      })
+      const loader = new StoreResourceLoader({ store })
+
+      const resources = await loader.byProperty(link)
+      const resource = resources[0]
+
+      strictEqual(term.equals(resource.term), true)
+      strictEqual(resource.dataset.size, 2)
+      strictEqual([...resource.types][0].value, 'http://example.org/Class')
+    })
+  })
+})

--- a/test/StoreResourceLoader.test.js
+++ b/test/StoreResourceLoader.test.js
@@ -40,11 +40,11 @@ describe('StoreResourceLoader', () => {
     })
   })
 
-  describe('.byClass', () => {
+  describe('.forClassOperation', () => {
     it('should be a method', () => {
       const loader = new StoreResourceLoader({ store: {} })
 
-      strictEqual(typeof loader.byClass, 'function')
+      strictEqual(typeof loader.forClassOperation, 'function')
     })
 
     it('should load term, dataset and types from the given named graph', async () => {
@@ -55,7 +55,7 @@ describe('StoreResourceLoader', () => {
       })
       const loader = new StoreResourceLoader({ store })
 
-      const resources = await loader.byClass(term)
+      const resources = await loader.forClassOperation(term)
       const resource = resources[0]
 
       strictEqual(term.equals(resource.term), true)
@@ -64,11 +64,11 @@ describe('StoreResourceLoader', () => {
     })
   })
 
-  describe('.byProperty', () => {
+  describe('.forPropertyOperation', () => {
     it('should be a method', () => {
       const loader = new StoreResourceLoader({ store: {} })
 
-      strictEqual(typeof loader.byProperty, 'function')
+      strictEqual(typeof loader.forPropertyOperation, 'function')
     })
 
     it('should load term, dataset and types from the given named graph', async () => {
@@ -80,7 +80,7 @@ describe('StoreResourceLoader', () => {
       })
       const loader = new StoreResourceLoader({ store })
 
-      const resources = await loader.byProperty(link)
+      const resources = await loader.forPropertyOperation(link)
       const resource = resources[0]
 
       strictEqual(term.equals(resource.term), true)

--- a/test/support/store/__index.nt
+++ b/test/support/store/__index.nt
@@ -1,0 +1,2 @@
+<http://example.org/> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/Class>.
+<http://example.org/> <http://example.org/predicate> <http://example.org/object>.


### PR DESCRIPTION
This PR moves the code to load the resource for class/property operations to a separate class `StoreResourceLoader` and allows using custom loaders not based on the RDF/JS Store interface.