### PR TITLE
feat: attach selected operation to express request object

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Additionally there is a `hydra` property assigned to `req` that contains more da
  
     // requested URL as RDF/JS NamedNode
     term,
+    
+    // the selected hydra:Operation as Graph Pointer
+    operation,
 
     // resource this request is about
     // This can be the requested URL for the case that a class operation is called.

--- a/lib/middleware/operation.js
+++ b/lib/middleware/operation.js
@@ -41,6 +41,7 @@ function factory (api) {
       return next()
     }
 
+    req.hydra.operation = operations[0]
     operation(req, res, next)
   }
 }


### PR DESCRIPTION
By adding the selected operation to `req.hydra` the handler middleware will have access to metadata about the operation.

Specifically, I'd like to use it to get the `sh:Shape` object of `hydra:expects`.