### PR TITLE
fix(iri-template): support multiple query params values

### DIFF
--- a/examples/blog/api.ttl
+++ b/examples/blog/api.ttl
@@ -37,9 +37,12 @@
   ], [ a hydra:IriTemplateMapping;
     hydra:property <to>;
     hydra:variable "to"
+  ], [ a hydra:IriTemplateMapping;
+    hydra:property <tag>;
+    hydra:variable "tag"
   ];
-  hydra:template "/{?from,to}";
-  hydra:variableRepresentation hydra:BasicRepresentation.
+  hydra:template "/{?from,to,tag}";
+  hydra:variableRepresentation hydra:BasicRepresentation .
 
 <Post> a hydra:Class;
   hydra:supportedOperation

--- a/examples/blog/blog.js
+++ b/examples/blog/blog.js
@@ -18,7 +18,14 @@ async function get (req, res) {
     const to = toQuad && toQuad.object
 
     if (from || to) {
-      console.log(`filter: ${from && from.value} - ${to && to.value}`)
+      console.log(`date filter: ${from && from.value} - ${to && to.value}`)
+    }
+
+    const tagQuad = [...filters.match(null, ns.schema.tag, null, null)][0]
+    const tag = tagQuad && tagQuad.object
+
+    if (tag) {
+      console.log(`tag filter: ${tag.value}`)
     }
 
     req.hydra.resource.dataset.add(rdf.quad(

--- a/examples/blog/blog.js
+++ b/examples/blog/blog.js
@@ -21,11 +21,11 @@ async function get (req, res) {
       console.log(`date filter: ${from && from.value} - ${to && to.value}`)
     }
 
-    const tagQuad = [...filters.match(null, ns.schema.tag, null, null)][0]
-    const tag = tagQuad && tagQuad.object
+    const tagQuads = [...filters.match(null, ns.schema.tag, null, null)]
+    const tags = tagQuads.map(tagQuad => tagQuad.object.value)
 
-    if (tag) {
-      console.log(`tag filter: ${tag.value}`)
+    if (tags) {
+      console.log(`tag filter: ${tags}`)
     }
 
     req.hydra.resource.dataset.add(rdf.quad(

--- a/examples/blog/blog.js
+++ b/examples/blog/blog.js
@@ -31,7 +31,7 @@ async function get (req, res) {
     req.hydra.resource.dataset.add(rdf.quad(
       req.hydra.term,
       vocab.hydra.view,
-      url,
+      url
     ))
   }
 

--- a/lib/middleware/iriTemplate.js
+++ b/lib/middleware/iriTemplate.js
@@ -31,8 +31,7 @@ function middleware ({ dataset, term, graph }) {
       return next()
     }
 
-    const subject = rdf.blankNode()
-    const dataset = rdf.dataset()
+    const templateParams = clownface({ dataset: rdf.dataset() }).blankNode()
 
     Object.entries(req.params).forEach(([key, value]) => {
       const property = variablePropertyMap.get(key)
@@ -41,15 +40,15 @@ function middleware ({ dataset, term, graph }) {
         return
       }
 
-      dataset.add(rdf.quad(subject, property, rdf.literal(value)))
+      templateParams.addOut(property, value)
     })
 
     req.dataset = () => {
-      return Promise.resolve(dataset)
+      return Promise.resolve(templateParams.dataset)
     }
 
     req.quadStream = () => {
-      return toStream(dataset)
+      return toStream(templateParams.dataset)
     }
 
     next()

--- a/test/iriTemplate.test.js
+++ b/test/iriTemplate.test.js
@@ -1,7 +1,7 @@
-const { strictEqual, ok } = require('assert')
+const { strictEqual } = require('assert')
 const express = require('express')
 const { describe, it } = require('mocha')
-const { fromStream, equals } = require('rdf-dataset-ext')
+const { fromStream } = require('rdf-dataset-ext')
 const rdf = { ...require('@rdfjs/data-model'), ...require('@rdfjs/dataset') }
 const request = require('supertest')
 const iriTemplateMappingBuilder = require('./support/iriTemplateMappingBuilder')
@@ -141,7 +141,7 @@ describe('middleware/iriTemplate', () => {
       app.use(middleware(iriTemplateMappingBuilder({
         template: '/{?tag*}',
         variables: {
-          tag: 'http://example.org/tag',
+          tag: 'http://example.org/tag'
         }
       })))
 
@@ -166,7 +166,7 @@ describe('middleware/iriTemplate', () => {
       app.use(middleware(iriTemplateMappingBuilder({
         template: '/{?tag}',
         variables: {
-          tag: 'http://example.org/tag',
+          tag: 'http://example.org/tag'
         }
       })))
 

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -19,7 +19,7 @@ describe('middleware/resource', () => {
     }
   })
 
-  function hydraMock(req, res, next) {
+  function hydraMock (req, res, next) {
     req.hydra = {
       term: RDF.namedNode(req.uri)
     }


### PR DESCRIPTION
This PR makes it possible to handle IRI Template requests with multiple values of a mapped variable, handing both flavours `foo=bar,baz` and `foo=bar&foo=baz`