### PR TITLE
feat: add middleware hook between resource loader and operation

### DIFF
--- a/lib/middleware/waitFor.js
+++ b/lib/middleware/waitFor.js
@@ -1,3 +1,4 @@
+const { Router } = require('express')
 const { asyncMiddleware } = require('middleware-async')
 
 function waitFor (promise, factory) {
@@ -7,7 +8,7 @@ function waitFor (promise, factory) {
     await promise
 
     if (!middleware) {
-      middleware = factory()
+      middleware = Router().use(factory())
     }
 
     middleware(req, res, next)

--- a/middleware.js
+++ b/middleware.js
@@ -13,7 +13,7 @@ const resource = require('./lib/middleware/resource')
 const waitFor = require('./lib/middleware/waitFor')
 const StoreResourceLoader = require('./StoreResourceLoader')
 
-function middleware (api, { baseIriFromRequest, loader, store } = {}) {
+function middleware (api, { baseIriFromRequest, loader, store, middleware = {} } = {}) {
   const init = defer()
   const router = new Router()
 
@@ -69,6 +69,9 @@ function middleware (api, { baseIriFromRequest, loader, store } = {}) {
     throw new Error('no loader or store provided')
   }
 
+  if (middleware.resource) {
+    router.use(waitFor(init, () => middleware.resource))
+  }
   router.use(waitFor(init, () => operation(api)))
 
   return router

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -13,7 +13,7 @@ describe('hydra-box', () => {
     api = {
       path: '/api',
       dataset: RDF.dataset(),
-      async init() {},
+      async init () {}
     }
   })
 
@@ -21,7 +21,7 @@ describe('hydra-box', () => {
     // given
     const loadedResource = {
       term: RDF.blankNode(),
-      types: [],
+      types: []
     }
     const app = express()
     const middleware = sinon.spy((req, res, next) => next())
@@ -45,7 +45,7 @@ describe('hydra-box', () => {
     // given
     const loadedResource = {
       term: RDF.blankNode(),
-      types: [],
+      types: []
     }
     const app = express()
     const middlewares = [
@@ -75,7 +75,7 @@ describe('hydra-box', () => {
     let receivedResource
     const loadedResource = {
       term: RDF.blankNode(),
-      types: [],
+      types: []
     }
     const app = express()
     const middleware = sinon.spy((req, res, next) => {

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -1,0 +1,100 @@
+const { describe, it, beforeEach } = require('mocha')
+const assert = require('assert')
+const express = require('express')
+const sinon = require('sinon')
+const request = require('supertest')
+const RDF = require('@rdfjs/dataset')
+const hydraBox = require('../middleware')
+
+describe('hydra-box', () => {
+  let api
+
+  beforeEach(() => {
+    api = {
+      path: '/api',
+      dataset: RDF.dataset(),
+      async init() {},
+    }
+  })
+
+  it('hooks up resource singular middleware', async () => {
+    // given
+    const loadedResource = {
+      term: RDF.blankNode(),
+      types: [],
+    }
+    const app = express()
+    const middleware = sinon.spy((req, res, next) => next())
+    app.use(hydraBox(api, {
+      loader: {
+        forClassOperation: () => [loadedResource]
+      },
+      middleware: {
+        resource: middleware
+      }
+    }))
+
+    // when
+    await request(app).get('/')
+
+    // then
+    assert(middleware.calledOnce)
+  })
+
+  it('hooks up multiple resource middlewares', async () => {
+    // given
+    const loadedResource = {
+      term: RDF.blankNode(),
+      types: [],
+    }
+    const app = express()
+    const middlewares = [
+      sinon.spy((req, res, next) => next()),
+      sinon.spy((req, res, next) => next())
+    ]
+    app.use(hydraBox(api, {
+      loader: {
+        forClassOperation: () => [loadedResource]
+      },
+      middleware: {
+        resource: middlewares
+      }
+    }))
+
+    // when
+    await request(app).get('/')
+
+    // then
+    middlewares.forEach(middleware => {
+      assert(middleware.calledOnce)
+    })
+  })
+
+  it('calls resource middleware after loader', async () => {
+    // given
+    let receivedResource
+    const loadedResource = {
+      term: RDF.blankNode(),
+      types: [],
+    }
+    const app = express()
+    const middleware = sinon.spy((req, res, next) => {
+      receivedResource = req.hydra.resource
+      next()
+    })
+    app.use(hydraBox(api, {
+      loader: {
+        forClassOperation: () => [loadedResource]
+      },
+      middleware: {
+        resource: middleware
+      }
+    }))
+
+    // when
+    await request(app).get('/')
+
+    // then
+    assert.strictEqual(receivedResource, loadedResource)
+  })
+})

--- a/test/resource.test.js
+++ b/test/resource.test.js
@@ -21,7 +21,7 @@ describe('middleware/resource', () => {
 
   function hydraMock (req, res, next) {
     req.hydra = {
-      term: RDF.namedNode(req.uri)
+      term: RDF.namedNode(req.url)
     }
     next()
   }


### PR DESCRIPTION
I'd like to have access to the `IncomingMessage` inside the resource loader. This way the loaded resource can be modified before passing it to the operation middleware.

This way I can dynamically alter the routing, for example by adding of removing `rdf:type` from resource based on auth information.