### PR TITLE
Refactor operation middleware

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -4,7 +4,7 @@ module.exports = (ns) => {
   if (ns) {
     return {
       debug: debug.extend(ns),
-        warn: debug.extend(ns).extend('warn'),
+      warn: debug.extend(ns).extend('warn'),
       error: debug.extend(ns).extend('error')
     }
   }

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,0 +1,17 @@
+const debug = require('debug')('hydra-box')
+
+module.exports = (ns) => {
+  if (ns) {
+    return {
+      debug: debug.extend(ns),
+        warn: debug.extend(ns).extend('warn'),
+      error: debug.extend(ns).extend('error')
+    }
+  }
+
+  return {
+    debug,
+    warn: debug.extend('warn'),
+    error: debug.extend('error')
+  }
+}

--- a/lib/middleware/iriTemplate.js
+++ b/lib/middleware/iriTemplate.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('hydra-box:iriTemplate')
+const { debug } = require('../log')('iriTemplate')
 const clownface = require('clownface')
 const { Router } = require('express')
 const ns = require('@tpluscode/rdf-ns-builders')

--- a/lib/middleware/operation.js
+++ b/lib/middleware/operation.js
@@ -12,14 +12,15 @@ function factory (api) {
     const operations = []
 
     const method = req.method === 'HEAD' ? 'GET' : req.method
+    const types = clownface({ ...api, term: [...req.hydra.resource.types] })
 
-    clownface({ ...api, term: [...req.hydra.resource.types] })
+    types
       .out(ns.hydra.supportedOperation)
       .has(ns.hydra.method, method).forEach(operation => {
         operations.push(operation)
       })
 
-    clownface({ ...api, term: [...req.hydra.resource.types] })
+    types
       .out(ns.hydra.supportedProperty)
       .out(ns.hydra.property)
       .out(ns.hydra.supportedOperation)

--- a/lib/middleware/operation.js
+++ b/lib/middleware/operation.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('hydra-box:operation')
+const { debug, warn } = require('../log')('operation')
 const clownface = require('clownface')
 const ns = require('@tpluscode/rdf-ns-builders')
 const { code } = require('../namespaces')
@@ -28,7 +28,7 @@ function factory (api) {
       })
 
     if (operations.length === 0) {
-      debug('no operations found')
+      warn('no operations found')
 
       return next()
     }
@@ -36,7 +36,7 @@ function factory (api) {
     const operation = api.loaderRegistry.load(operations[0].out(code.implementedBy), { basePath: api.codePath })
 
     if (!operation) {
-      debug('could not load operation')
+      warn('could not load operation')
 
       return next()
     }

--- a/lib/middleware/operation.js
+++ b/lib/middleware/operation.js
@@ -10,9 +10,9 @@ function findClassOperations (types, method) {
     .toArray()
 }
 
-function findPropertyOperations (req, types, method) {
-  const properties = [...req.hydra.resource.dataset
-    .match(req.hydra.resource.term, null, req.hydra.term)]
+function findPropertyOperations (types, method, term, resource) {
+  const properties = [...resource.dataset
+    .match(resource.term, null, term)]
     .map(({ predicate }) => predicate)
 
   return types
@@ -38,9 +38,9 @@ function factory (api) {
       // only look for direct operation when the root resource is requested
       operations = findClassOperations(types, method)
     }
-    if (!operations.some(Boolean)) {
+    if (operations.length === 0) {
       // otherwise try finding the operation by property usage
-      operations = findPropertyOperations(req, types, method)
+      operations = findPropertyOperations(types, method, req.hydra.term, req.hydra.resource)
     }
 
     const [operation, ...rest] = operations
@@ -51,7 +51,7 @@ function factory (api) {
       return next()
     }
 
-    if (rest.some(Boolean)) {
+    if (rest.length > 0) {
       error('Multiple operations found')
       return next(new Error('Ambiguous operation'))
     }

--- a/lib/middleware/operation.js
+++ b/lib/middleware/operation.js
@@ -1,7 +1,28 @@
-const { debug, warn } = require('../log')('operation')
+const { error, warn } = require('../log')('operation')
 const clownface = require('clownface')
 const ns = require('@tpluscode/rdf-ns-builders')
 const { code } = require('../namespaces')
+
+function findClassOperations (types, method) {
+  return types
+    .out(ns.hydra.supportedOperation)
+    .has(ns.hydra.method, method)
+    .toArray()
+}
+
+function findPropertyOperations (req, types, method) {
+  const properties = [...req.hydra.resource.dataset
+    .match(req.hydra.resource.term, null, req.hydra.term)]
+    .map(({ predicate }) => predicate)
+
+  return types
+    .out(ns.hydra.supportedProperty)
+    .has(ns.hydra.property, properties)
+    .out(ns.hydra.property)
+    .out(ns.hydra.supportedOperation)
+    .has(ns.hydra.method, method)
+    .toArray()
+}
 
 function factory (api) {
   return (req, res, next) => {
@@ -9,41 +30,40 @@ function factory (api) {
       return next()
     }
 
-    const operations = []
-
     const method = req.method === 'HEAD' ? 'GET' : req.method
     const types = clownface({ ...api, term: [...req.hydra.resource.types] })
 
-    types
-      .out(ns.hydra.supportedOperation)
-      .has(ns.hydra.method, method).forEach(operation => {
-        operations.push(operation)
-      })
+    let operations = []
+    if (req.hydra.term.equals(req.hydra.resource.term)) {
+      // only look for direct operation when the root resource is requested
+      operations = findClassOperations(types, method)
+    }
+    if (!operations.some(Boolean)) {
+      // otherwise try finding the operation by property usage
+      operations = findPropertyOperations(req, types, method)
+    }
 
-    types
-      .out(ns.hydra.supportedProperty)
-      .out(ns.hydra.property)
-      .out(ns.hydra.supportedOperation)
-      .has(ns.hydra.method, method).forEach(operation => {
-        operations.push(operation)
-      })
+    const [operation, ...rest] = operations
 
-    if (operations.length === 0) {
+    if (!operation) {
       warn('no operations found')
 
       return next()
     }
 
-    const operation = api.loaderRegistry.load(operations[0].out(code.implementedBy), { basePath: api.codePath })
-
-    if (!operation) {
-      warn('could not load operation')
-
-      return next()
+    if (rest.some(Boolean)) {
+      error('Multiple operations found')
+      return next(new Error('Ambiguous operation'))
     }
 
-    req.hydra.operation = operations[0]
-    operation(req, res, next)
+    const handler = api.loaderRegistry.load(operation.out(code.implementedBy), { basePath: api.codePath })
+
+    if (!handler) {
+      return next(new Error('Failed to load operation'))
+    }
+
+    req.hydra.operation = operation
+    handler(req, res, next)
   }
 }
 

--- a/lib/middleware/resource.js
+++ b/lib/middleware/resource.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('hydra-box:resource')
+const { debug } = require('../log')('resource')
 
 function factory ({ loader }) {
   return async (req, res, next) => {

--- a/middleware.js
+++ b/middleware.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('hydra-box:middleware')
+const { debug } = require('./lib/log')('middleware')
 const absoluteUrl = require('absolute-url')
 const { Router } = require('express')
 const { defer } = require('promise-the-world')

--- a/test/operation.test.js
+++ b/test/operation.test.js
@@ -32,11 +32,15 @@ describe('middleware/operation', () => {
       })
   })
 
-  function hydraMock(resource, rootResource) {
+  function hydraMock ({ types = [], term, dataset = RDF.dataset() } = {}, rootResource) {
     return function (req, res, next) {
       req.hydra = {
-        term: RDF.namedNode(rootResource || req.url),
-        resource,
+        term: RDF.namedNode(req.url),
+        resource: {
+          dataset,
+          term: rootResource ? RDF.namedNode(rootResource) : term || RDF.namedNode(req.url),
+          types
+        }
       }
       next()
     }
@@ -45,21 +49,24 @@ describe('middleware/operation', () => {
   it('calls next middleware when no resource was loaded', async () => {
     // given
     const app = express()
-    app.use(hydraMock())
+    app.use((req, res, next) => {
+      req.hydra = {}
+      next()
+    })
     app.use(middleware(api))
 
     // when
     const response = await request(app).get('/')
 
     // then
-    assert.strictEqual(response.status,404)
+    assert.strictEqual(response.status, 404)
   })
 
-  it('calls next middleware when no operation is found', async () => {
+  it('calls next middleware when class is not supported', async () => {
     // given
     const app = express()
     app.use(hydraMock({
-      types: [NS.NoSuchClass],
+      types: [NS.NoSuchClass]
     }))
     app.use(middleware(api))
 
@@ -67,14 +74,29 @@ describe('middleware/operation', () => {
     const response = await request(app).get('/')
 
     // then
-    assert.strictEqual(response.status,404)
+    assert.strictEqual(response.status, 404)
+  })
+
+  it('calls next middleware when no operation is found', async () => {
+    // given
+    const app = express()
+    app.use(hydraMock({
+      types: [NS.Person]
+    }))
+    app.use(middleware(api))
+
+    // when
+    const response = await request(app).patch('/')
+
+    // then
+    assert.strictEqual(response.status, 404)
   })
 
   it('calls GET handler when HEAD is requested', async () => {
     // given
     const app = express()
     app.use(hydraMock({
-      types: [NS.Person],
+      types: [NS.Person]
     }))
     app.use(middleware(api))
 
@@ -82,7 +104,7 @@ describe('middleware/operation', () => {
     const response = await request(app).head('/')
 
     // then
-    assert.strictEqual(response.status,200)
+    assert.strictEqual(response.status, 200)
     assert(api.loaderRegistry.load.calledOnceWith(
       sinon.match.hasNested('term.value', sinon.match(/person-get$/)),
       sinon.match.any
@@ -99,7 +121,7 @@ describe('middleware/operation', () => {
     app.use(hydraMock({
       types: [NS.Person],
       term: '/friends',
-      dataset,
+      dataset
     }, '/john-doe'))
     app.use(middleware(api))
 
@@ -107,10 +129,84 @@ describe('middleware/operation', () => {
     const response = await request(app).post('/friends')
 
     // then
-    assert.strictEqual(response.status,200)
+    assert.strictEqual(response.status, 200)
     assert(api.loaderRegistry.load.calledOnceWith(
       sinon.match.hasNested('term.value', sinon.match(/friends-post$/)),
       sinon.match.any
     ))
+  })
+
+  it('does not call supported property operation when resource does not match', async () => {
+    // given
+    const app = express()
+    const dataset = RDF.dataset()
+    clownface({ dataset })
+      .namedNode('/john-doe')
+      .addOut(NS.friends, RDF.namedNode('/friends'))
+    app.use(hydraMock({
+      types: [NS.Person],
+      term: '/friends',
+      dataset
+    }, '/john-doe'))
+    app.use(middleware(api))
+
+    // when
+    const response = await request(app).post('/john-doe')
+
+    // then
+    assert.strictEqual(response.status, 404)
+    assert(api.loaderRegistry.load.notCalled)
+  })
+
+  it('throws when multiple operations are found for class', async () => {
+    // given
+    const app = express()
+    app.use(hydraMock({
+      types: [NS.Person]
+    }))
+    app.use(middleware(api))
+
+    // when
+    const response = await request(app).delete('/foo')
+
+    // then
+    assert.strictEqual(response.status, 500)
+  })
+
+  it('throws when multiple operations are found for property object', async () => {
+    // given
+    const app = express()
+    const dataset = RDF.dataset()
+    clownface({ dataset })
+      .namedNode('/john-doe')
+      .addOut(NS.interests, RDF.namedNode('/john-doe/interests'))
+    app.use(hydraMock({
+      types: [NS.Person],
+      term: '/john-doe/interests',
+      dataset
+    }, '/john-doe'))
+    app.use(middleware(api))
+
+    // when
+    const response = await request(app).get('/john-doe/interests')
+
+    // then
+    assert.strictEqual(response.status, 500)
+  })
+
+  it('throws when operation fails to load', async () => {
+    // given
+    const app = express()
+    app.use(hydraMock({
+      types: [NS.Person]
+    }))
+    app.use(middleware(api))
+
+    // when
+    api.loaderRegistry.load.returns(null)
+    const response = await request(app).get('/john-doe')
+
+    // then
+    assert.strictEqual(response.status, 500)
   })
 })

--- a/test/operation.test.js
+++ b/test/operation.test.js
@@ -1,0 +1,116 @@
+const assert = require('assert')
+const path = require('path')
+const { describe, it, beforeEach } = require('mocha')
+const express = require('express')
+const RDF = require('@rdfjs/dataset')
+const clownface = require('clownface')
+const { fromFile } = require('rdf-utils-fs')
+const { fromStream } = require('rdf-dataset-ext')
+const request = require('supertest')
+const sinon = require('sinon')
+const namespace = require('@rdfjs/namespace')
+const middleware = require('../lib/middleware/operation')
+
+const NS = namespace('http://example.com/')
+
+describe('middleware/operation', () => {
+  let api
+
+  beforeEach(async () => {
+    api = {
+      dataset: await fromStream(RDF.dataset(), fromFile(path.resolve(__dirname, 'support/operationTestCases.ttl'))),
+      term: NS.api,
+      loaderRegistry: {
+        load: sinon.stub()
+      }
+    }
+
+    api.loaderRegistry.load
+      .returns((req, res) => {
+        res.status(200)
+        res.end()
+      })
+  })
+
+  function hydraMock(resource, rootResource) {
+    return function (req, res, next) {
+      req.hydra = {
+        term: RDF.namedNode(rootResource || req.url),
+        resource,
+      }
+      next()
+    }
+  }
+
+  it('calls next middleware when no resource was loaded', async () => {
+    // given
+    const app = express()
+    app.use(hydraMock())
+    app.use(middleware(api))
+
+    // when
+    const response = await request(app).get('/')
+
+    // then
+    assert.strictEqual(response.status,404)
+  })
+
+  it('calls next middleware when no operation is found', async () => {
+    // given
+    const app = express()
+    app.use(hydraMock({
+      types: [NS.NoSuchClass],
+    }))
+    app.use(middleware(api))
+
+    // when
+    const response = await request(app).get('/')
+
+    // then
+    assert.strictEqual(response.status,404)
+  })
+
+  it('calls GET handler when HEAD is requested', async () => {
+    // given
+    const app = express()
+    app.use(hydraMock({
+      types: [NS.Person],
+    }))
+    app.use(middleware(api))
+
+    // when
+    const response = await request(app).head('/')
+
+    // then
+    assert.strictEqual(response.status,200)
+    assert(api.loaderRegistry.load.calledOnceWith(
+      sinon.match.hasNested('term.value', sinon.match(/person-get$/)),
+      sinon.match.any
+    ))
+  })
+
+  it('calls supported property operation handler when matched to nested resource', async () => {
+    // given
+    const app = express()
+    const dataset = RDF.dataset()
+    clownface({ dataset })
+      .namedNode('/john-doe')
+      .addOut(NS.friends, RDF.namedNode('/friends'))
+    app.use(hydraMock({
+      types: [NS.Person],
+      term: '/friends',
+      dataset,
+    }, '/john-doe'))
+    app.use(middleware(api))
+
+    // when
+    const response = await request(app).post('/friends')
+
+    // then
+    assert.strictEqual(response.status,200)
+    assert(api.loaderRegistry.load.calledOnceWith(
+      sinon.match.hasNested('term.value', sinon.match(/friends-post$/)),
+      sinon.match.any
+    ))
+  })
+})

--- a/test/support/operationTestCases.ttl
+++ b/test/support/operationTestCases.ttl
@@ -1,0 +1,17 @@
+@base          <http://example.com/> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix code:  <https://code.described.at/> .
+
+<api>
+    hydra:supportedClass <Person> .
+
+<Person>
+    hydra:supportedOperation [ hydra:method       "GET" ;
+                               code:implementedBy _:person-get ] ;
+    hydra:supportedProperty  [ hydra:property <friends> ] ;
+.
+
+<friends> a hydra:Link ;
+    hydra:supportedOperation [ hydra:method       "POST" ;
+                               code:implementedBy _:friends-post ] ;
+.

--- a/test/support/operationTestCases.ttl
+++ b/test/support/operationTestCases.ttl
@@ -8,10 +8,26 @@
 <Person>
     hydra:supportedOperation [ hydra:method       "GET" ;
                                code:implementedBy _:person-get ] ;
+    hydra:supportedOperation [ hydra:method       "DELETE" ;
+                               code:implementedBy [] ] ;
+    hydra:supportedOperation [ hydra:method       "DELETE" ;
+                               code:implementedBy [] ] ;
     hydra:supportedProperty  [ hydra:property <friends> ] ;
+    hydra:supportedProperty  [ hydra:property <interests> ] ;
 .
 
-<friends> a hydra:Link ;
+<friends>
+    a                        hydra:Link ;
     hydra:supportedOperation [ hydra:method       "POST" ;
                                code:implementedBy _:friends-post ] ;
+.
+
+<interests>
+    a                        hydra:Link ;
+    hydra:supportedOperation [ hydra:method       "POST" ;
+                               code:implementedBy _:interests-post ] ;
+    hydra:supportedOperation [ hydra:method       "GET" ;
+                               code:implementedBy [] ] ;
+    hydra:supportedOperation [ hydra:method       "GET" ;
+                               code:implementedBy [] ] ;
 .


### PR DESCRIPTION
I implemented a bunch of improvements to the operation selection process:

2. Only consider class' operations when the resource URI equals request URI
3. For property operations, only select those where property object equals request URI
1. Fail request when multiple operations are found
4. Fail request when loader registry fails to load operation

This fixe a bunch of broken scenarios such as multiple properties supporting a given method (like multiple nested collections which accept `POST`) and calling a random property operation when the class does not support a given method