### PR TITLE
feat: support hydra:ExplicitRepresentation for iri templates

### DIFF
--- a/lib/middleware/iriTemplate.js
+++ b/lib/middleware/iriTemplate.js
@@ -6,6 +6,32 @@ const rdf = { ...require('@rdfjs/data-model'), ...require('@rdfjs/dataset') }
 const { toStream } = require('rdf-dataset-ext')
 const uriTemplateRoute = require('uri-template-route')
 
+const literalValueRegex = /^"(?<value>.+)"(@|\^\^)?((?<=@)(?<language>.*))?((?<=\^\^)(?<datatype>.*))?$/
+
+/**
+ *
+ * @param {Clownface} template
+ * @param {string} value
+ * @returns {NamedNode|Literal|string}
+ */
+function createTermFromVariable ({ template, value }) {
+  if (!ns.hydra.ExplicitRepresentation.equals(template.out(ns.hydra.variableRepresentation).term)) {
+    return value
+  }
+
+  const matches = value.match(literalValueRegex)
+  if (matches) {
+    let datatypeOrLanguage = matches.groups.language
+    if (matches.groups.datatype) {
+      datatypeOrLanguage = rdf.namedNode(matches.groups.datatype)
+    }
+
+    return rdf.literal(matches.groups.value, datatypeOrLanguage)
+  }
+
+  return rdf.namedNode(value)
+}
+
 function middleware ({ dataset, term, graph }) {
   const iriTemplateNode = clownface({ dataset, term, graph })
   const template = iriTemplateNode.out(ns.hydra.template).value
@@ -40,7 +66,7 @@ function middleware ({ dataset, term, graph }) {
         return
       }
 
-      templateParams.addOut(property, value)
+      templateParams.addOut(property, createTermFromVariable({ template: iriTemplateNode, value }))
     })
 
     req.dataset = () => {

--- a/test/support/iriTemplateMappingBuilder.js
+++ b/test/support/iriTemplateMappingBuilder.js
@@ -6,7 +6,8 @@ function iriTemplateMappingBuilder ({
   term = rdf.blankNode(),
   graph = rdf.defaultGraph(),
   template,
-  variables
+  variables,
+  explicitRepresentation
 } = {}) {
   dataset.add(rdf.quad(term, ns.rdf.type, ns.hydra.IriTemplate, graph))
 
@@ -22,6 +23,10 @@ function iriTemplateMappingBuilder ({
       dataset.add(rdf.quad(mapping, ns.hydra.variable, rdf.literal(key), graph))
       dataset.add(rdf.quad(mapping, ns.hydra.property, rdf.namedNode(value), graph))
     })
+  }
+
+  if (explicitRepresentation) {
+    dataset.add(rdf.quad(term, ns.hydra.variableRepresentation, ns.hydra.ExplicitRepresentation))
   }
 
   return {


### PR DESCRIPTION
This adds support for parsing IRI template queries where `hydra:ExplcitRepresentation` is required.

The test cases are taken from the [examples shown in the specification](http://www.hydra-cg.com/spec/latest/core/#example-22-the-different-variable-representations)