### PR TITLE
fix: handle promise rejection in handlers

### DIFF
--- a/lib/middleware/waitFor.js
+++ b/lib/middleware/waitFor.js
@@ -1,7 +1,9 @@
+const { asyncMiddleware } = require('middleware-async')
+
 function waitFor (promise, factory) {
   let middleware = null
 
-  return async (req, res, next) => {
+  return asyncMiddleware(async (req, res, next) => {
     await promise
 
     if (!middleware) {
@@ -9,7 +11,7 @@ function waitFor (promise, factory) {
     }
 
     middleware(req, res, next)
-  }
+  })
 }
 
 module.exports = waitFor

--- a/middleware.js
+++ b/middleware.js
@@ -1,6 +1,7 @@
 const debug = require('debug')('hydra-box:middleware')
 const absoluteUrl = require('absolute-url')
 const { Router } = require('express')
+const { asyncMiddleware } = require('middleware-async')
 const { defer } = require('promise-the-world')
 const rdf = { ...require('@rdfjs/data-model'), ...require('@rdfjs/dataset') }
 const rdfHandler = require('@rdfjs/express-handler')
@@ -18,7 +19,7 @@ function middleware (api, { baseIriFromRequest, loader, store } = {}) {
 
   router.use(absoluteUrl())
   router.use(setLink)
-  router.use(async (req, res, next) => {
+  router.use(asyncMiddleware(async (req, res, next) => {
     const iri = new URL(req.absoluteUrl())
 
     iri.search = ''
@@ -54,7 +55,7 @@ function middleware (api, { baseIriFromRequest, loader, store } = {}) {
 
       next(err)
     }
-  })
+  }))
 
   router.use(rdfHandler({ baseIriFromRequest, sendTriples: true }))
   router.use(waitFor(init, () => apiHeader(api)))

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "clownface": "^0.12.1",
     "debug": "^4.1.1",
     "express": "^4.17.1",
+    "middleware-async": "^1.2.6",
     "promise-the-world": "^1.0.1",
     "rdf-dataset-ext": "^1.0.0",
     "rdf-loader-code": "^0.3.0",


### PR DESCRIPTION
Wrapping all middleware which returns a promise in `middleware-async` ensures that promise rejection is handled gracefully.

Currently the API just logs an unhandled rejection and not response is ever sent to the client.