### PR TITLE
fix: introduce separate dataset only for finding operations

### DIFF
--- a/StoreResourceLoader.js
+++ b/StoreResourceLoader.js
@@ -20,7 +20,10 @@ class StoreResourceLoader {
 
     return {
       term,
-      dataset,
+      prefetchDataset: dataset,
+      async dataset () {
+        return dataset
+      },
       types
     }
   }

--- a/StoreResourceLoader.js
+++ b/StoreResourceLoader.js
@@ -1,6 +1,6 @@
 const clownface = require('clownface')
 const ns = require('@tpluscode/rdf-ns-builders')
-const { fromStream } = require('rdf-dataset-ext')
+const { fromStream, toStream } = require('rdf-dataset-ext')
 const rdf = { ...require('@rdfjs/data-model'), ...require('@rdfjs/dataset') }
 const TermSet = require('@rdfjs/term-set')
 
@@ -23,6 +23,9 @@ class StoreResourceLoader {
       prefetchDataset: dataset,
       async dataset () {
         return dataset
+      },
+      quadStream () {
+        return toStream(dataset)
       },
       types
     }

--- a/examples/blog/blog.js
+++ b/examples/blog/blog.js
@@ -8,6 +8,7 @@ const validate = require('./lib/validate')
 async function get (req, res) {
   const url = rdf.namedNode(req.absoluteUrl())
 
+  const dataset = await req.hydra.resource.dataset()
   if (req.dataset) {
     const filters = await req.dataset()
 
@@ -28,14 +29,14 @@ async function get (req, res) {
       console.log(`tag filter: ${tags}`)
     }
 
-    req.hydra.resource.dataset.add(rdf.quad(
+    dataset.add(rdf.quad(
       req.hydra.term,
       vocab.hydra.view,
       url
     ))
   }
 
-  res.dataset(req.hydra.resource.dataset)
+  res.dataset(dataset)
 }
 
 async function post (req, res, next) {

--- a/examples/blog/category.js
+++ b/examples/blog/category.js
@@ -1,5 +1,5 @@
-function get (req, res) {
-  res.dataset(req.hydra.resource.dataset)
+async function get (req, res) {
+  res.dataset(await req.hydra.resource.dataset())
 }
 
 module.exports = {

--- a/examples/blog/post.js
+++ b/examples/blog/post.js
@@ -1,5 +1,5 @@
-function get (req, res) {
-  res.dataset(req.hydra.resource.dataset)
+async function get (req, res) {
+  res.dataset(await req.hydra.resource.dataset())
 }
 
 module.exports = {

--- a/lib/middleware/operation.js
+++ b/lib/middleware/operation.js
@@ -19,7 +19,7 @@ function findPropertyOperations ({ resource, api, method }) {
   const apiGraph = clownface(api)
   const types = apiGraph.node([...resource.types])
 
-  const properties = [...resource.dataset
+  const properties = [...resource.prefetchDataset
     .match(resource.term, resource.property, resource.object)]
     .map(({ predicate }) => predicate)
 

--- a/test/StoreResourceLoader.test.js
+++ b/test/StoreResourceLoader.test.js
@@ -35,7 +35,7 @@ describe('StoreResourceLoader', () => {
       const resource = await loader.load(term)
 
       strictEqual(term.equals(resource.term), true)
-      strictEqual(resource.dataset.size, 2)
+      strictEqual((await resource.dataset()).size, 2)
       strictEqual([...resource.types][0].value, 'http://example.org/Class')
     })
   })
@@ -59,7 +59,7 @@ describe('StoreResourceLoader', () => {
       const resource = resources[0]
 
       strictEqual(term.equals(resource.term), true)
-      strictEqual(resource.dataset.size, 2)
+      strictEqual((await resource.dataset()).size, 2)
       strictEqual([...resource.types][0].value, 'http://example.org/Class')
     })
   })
@@ -84,7 +84,7 @@ describe('StoreResourceLoader', () => {
       const resource = resources[0]
 
       strictEqual(term.equals(resource.term), true)
-      strictEqual(resource.dataset.size, 2)
+      strictEqual((await resource.dataset()).size, 2)
       strictEqual([...resource.types][0].value, 'http://example.org/Class')
     })
   })

--- a/test/StoreResourceLoader.test.js
+++ b/test/StoreResourceLoader.test.js
@@ -1,6 +1,7 @@
 const { strictEqual } = require('assert')
 const { resolve } = require('path')
 const { describe, it } = require('mocha')
+const { fromStream } = require('rdf-dataset-ext')
 const rdf = { ...require('@rdfjs/data-model'), ...require('@rdfjs/dataset') }
 const FlatMultiFileStore = require('rdf-store-fs/FlatMultiFileStore')
 const StoreResourceLoader = require('../StoreResourceLoader')
@@ -36,6 +37,22 @@ describe('StoreResourceLoader', () => {
 
       strictEqual(term.equals(resource.term), true)
       strictEqual((await resource.dataset()).size, 2)
+      strictEqual([...resource.types][0].value, 'http://example.org/Class')
+    })
+
+    it('attaches quadStream getter to resource', async () => {
+      const term = rdf.namedNode('http://example.org/')
+      const store = new FlatMultiFileStore({
+        baseIRI: 'http://example.org/',
+        path: resolve(__dirname, 'support/store')
+      })
+      const loader = new StoreResourceLoader({ store })
+
+      const resource = await loader.load(term)
+      const dataset = await fromStream(rdf.dataset(), resource.quadStream())
+
+      strictEqual(term.equals(resource.term), true)
+      strictEqual(dataset.size, 2)
       strictEqual([...resource.types][0].value, 'http://example.org/Class')
     })
   })

--- a/test/operation.test.js
+++ b/test/operation.test.js
@@ -32,12 +32,12 @@ describe('middleware/operation', () => {
       })
   })
 
-  function testResource ({ types = [], term, dataset = RDF.dataset(), property, object } = {}) {
+  function testResource ({ types = [], term, prefetchDataset = RDF.dataset(), property, object } = {}) {
     if (property && object) {
       return {
         term,
         types,
-        dataset,
+        prefetchDataset,
         property,
         object
       }
@@ -46,7 +46,7 @@ describe('middleware/operation', () => {
     return {
       term,
       types,
-      dataset
+      prefetchDataset
     }
   }
 
@@ -169,7 +169,7 @@ describe('middleware/operation', () => {
       term: RDF.namedNode('/john-doe'),
       property: NS.friends,
       object: RDF.namedNode('/friends'),
-      dataset
+      prefetchDataset: dataset
     })))
     app.use(middleware())
 
@@ -196,7 +196,7 @@ describe('middleware/operation', () => {
       term: RDF.namedNode('/john-doe'),
       property: NS.friends,
       object: RDF.namedNode('/friends'),
-      dataset
+      prefetchDataset: dataset
     })))
     app.use(middleware())
 
@@ -235,7 +235,7 @@ describe('middleware/operation', () => {
       term: RDF.namedNode('/john-doe'),
       property: NS.interests,
       object: RDF.namedNode('/john-doe/interests'),
-      dataset
+      prefetchDataset: dataset
     })))
     app.use(middleware())
 


### PR DESCRIPTION
Proposed change to allow loaders to only load a minimum quads necessary for finding operations (working name `prefechDataset`) with the full resource dataset available on-demand using an async function.

We could also add a similar `.quadStream()` function?