### PR TITLE
feat: utility getter of clownface resource pointer

### DIFF
--- a/lib/middleware/operation.js
+++ b/lib/middleware/operation.js
@@ -74,6 +74,13 @@ function prepareOperation (req, res, next) {
   }
 
   const [{ resource, operation }] = req.hydra.operations
+  resource.clownface = async function () {
+    return clownface({
+      term: this.term,
+      dataset: await this.dataset()
+    })
+  }
+
   req.hydra.resource = resource
   req.hydra.operation = operation
   return next()

--- a/test/operation.test.js
+++ b/test/operation.test.js
@@ -159,16 +159,15 @@ describe('middleware/operation', () => {
     ))
   })
 
-  it('attaches a getter of clownface pointer', async () => {
+  it('attaches a getter of clownface pointer wrapping resource dataset', async () => {
     // given
     const app = express()
     let ptr = null
+    const dataset = RDF.dataset()
     app.use(hydraMock(testResource({
       types: [NS.Person],
       term: RDF.namedNode('/john-doe'),
-      dataset: async () => {
-        return RDF.dataset()
-      }
+      dataset: async () => dataset
     })))
     app.use(middleware())
     api.loaderRegistry.load.returns(async (req, res) => {
@@ -181,6 +180,7 @@ describe('middleware/operation', () => {
 
     // then
     assert.notStrictEqual(ptr.term, RDF.namedNode('/john-doe'))
+    assert.strictEqual(ptr.dataset, dataset)
   })
 
   it('calls supported property operation handler when matched to nested resource', async () => {


### PR DESCRIPTION
Since `0.6` introduce a breaking change making it difficult to get a pointer out of a resource object, this PR adds a handy function which wraps the request using clownface

**Before** 

```js
import clownface from 'clownface'

function handler(req) {
  const pointer = clownface(req.hydra.resource)
}
```

**Now**

Turned async because the entire dataset representation is no longer fetched in full by the loader

```js
async function handler(req) {
  const pointer = await req.hydra.resource.clownface()
}
```