### PR TITLE
fix: initializing API Documentation in router

### DIFF
--- a/lib/middleware/apiHeader.js
+++ b/lib/middleware/apiHeader.js
@@ -1,17 +1,10 @@
-const { join } = require('path')
-const { URL } = require('url')
 const { Router } = require('express')
 
 function factory (api) {
   const router = new Router()
 
   router.use((req, res, next) => {
-    const docUrl = new URL(req.absoluteUrl())
-
-    docUrl.pathname = join(req.baseUrl, api.path)
-    docUrl.search = ''
-
-    res.setLink(docUrl.toString(), 'http://www.w3.org/ns/hydra/core#apiDocumentation')
+    res.setLink(api.term.value, 'http://www.w3.org/ns/hydra/core#apiDocumentation')
 
     next()
   })

--- a/middleware.js
+++ b/middleware.js
@@ -1,6 +1,7 @@
 const { debug } = require('./lib/log')('middleware')
 const absoluteUrl = require('absolute-url')
 const { Router } = require('express')
+const path = require('path')
 const { asyncMiddleware } = require('middleware-async')
 const { defer } = require('promise-the-world')
 const rdf = { ...require('@rdfjs/data-model'), ...require('@rdfjs/dataset') }
@@ -35,10 +36,9 @@ function middleware (api, { baseIriFromRequest, loader, store, middleware = {} }
     }
 
     if (!api.term) {
-      const apiIri = new URL(iri)
+      const apiIri = new URL(path.join(req.baseUrl, api.path), iri)
 
-      apiIri.pathname = api.path
-
+      // api.path = apiIri.pathname
       api.term = rdf.namedNode(apiIri.toString())
 
       debug(`api.term was not set. Will use: ${api.term.value}`)

--- a/middleware.js
+++ b/middleware.js
@@ -38,7 +38,6 @@ function middleware (api, { baseIriFromRequest, loader, store, middleware = {} }
     if (!api.term) {
       const apiIri = new URL(path.join(req.baseUrl, api.path), iri)
 
-      // api.path = apiIri.pathname
       api.term = rdf.namedNode(apiIri.toString())
 
       debug(`api.term was not set. Will use: ${api.term.value}`)

--- a/test/apiHeader.test.js
+++ b/test/apiHeader.test.js
@@ -1,3 +1,4 @@
+const assert = require('assert')
 const { describe, it } = require('mocha')
 const express = require('express')
 const request = require('supertest')
@@ -6,6 +7,7 @@ const absoluteUrl = require('absolute-url')
 const setLink = require('set-link')
 const rdfHandler = require('@rdfjs/express-handler')
 const apiHeader = require('../lib/middleware/apiHeader')
+const ns = require('../lib/namespaces')
 
 function createApp () {
   const app = express()
@@ -21,6 +23,7 @@ describe('middleware/apiHeader', () => {
 
     app.use(apiHeader({
       path: '/api',
+      term: $rdf.namedNode('http://example.app/api'),
       dataset: $rdf.dataset()
     }))
 
@@ -29,5 +32,26 @@ describe('middleware/apiHeader', () => {
       .set('accept', 'text/html')
 
     await response.expect(406)
+  })
+
+  it('sets response link to the API', async () => {
+    const app = createApp()
+
+    app.use(apiHeader({
+      path: 'api',
+      term: $rdf.namedNode('http://example.app/sub-path/api'),
+      dataset: $rdf.dataset()
+    }))
+    app.use((req, res) => {
+      res.send(200)
+    })
+
+    const response = request(app).get('/')
+
+    await response.expect(res => {
+      const containsPath = new RegExp(`<http://example.app/sub-path/api>; rel="${ns.hydra.apiDocumentation.value}"`)
+
+      assert.match(res.headers['link'], containsPath)
+    })
   })
 })

--- a/test/apiHeader.test.js
+++ b/test/apiHeader.test.js
@@ -34,7 +34,7 @@ describe('middleware/apiHeader', () => {
     await response.expect(406)
   })
 
-  it('sets response link to the API', async () => {
+  it('sets API documentation URL link to the response', async () => {
     const app = createApp()
 
     app.use(apiHeader({

--- a/test/apiHeader.test.js
+++ b/test/apiHeader.test.js
@@ -51,7 +51,7 @@ describe('middleware/apiHeader', () => {
     await response.expect(res => {
       const containsPath = new RegExp(`<http://example.app/sub-path/api>; rel="${ns.hydra.apiDocumentation.value}"`)
 
-      assert.match(res.headers['link'], containsPath)
+      assert.match(res.headers.link, containsPath)
     })
   })
 })

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -210,5 +210,28 @@ describe('hydra-box', () => {
         assert.strictEqual(toCanonical(output), toCanonical(dataset))
       })
     })
+
+    it('should host the Api at the path given in the Api object if it is mounde on sub path', async () => {
+      await withServer(async server => {
+        const dataset = RDF.dataset([
+          RDF.quad(ns.example.subject, ns.example.predicate, RDF.literal('test'))
+        ])
+
+        server.app.use('/path/to/app', hydraBox(new Api({ dataset, path: '/api' }), {
+          loader: {
+            forClassOperation: () => [],
+            forPropertyOperation: () => []
+          }
+        }))
+
+        const url = new URL(await server.listen())
+        url.pathname = '/path/to/app/api'
+
+        const res = await rdfFetch(url.toString())
+        const output = await res.dataset()
+
+        assert.strictEqual(toCanonical(output), toCanonical(dataset))
+      })
+    })
   })
 })


### PR DESCRIPTION
This PR aims to improve a possible issue encountered when hosting a hydra-box inside a sub-path router where the API URL can be incorrect