### PR TITLE
fix: allow handlers after hydra-box

### DIFF
--- a/lib/middleware/operation.js
+++ b/lib/middleware/operation.js
@@ -98,7 +98,7 @@ async function invokeOperation (req, res, next) {
     if (!allowedMethods.size) {
       warn('no operations found')
       if (operationMap.every(({ resource }) => 'property' in resource)) {
-        return next(new createError.NotFound())
+        return next()
       }
       return next(new createError.MethodNotAllowed())
     }


### PR DESCRIPTION
Currently, when no operation is found, a `NotFoundError` is returned.

This way no handlers are called after hydra-box. It's not necessary in order to return a 404 and unnecessary limiting